### PR TITLE
Remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,6 @@ plainwhite:
   disqus_shortname: games
 ```
 
-**Google Analytics**
-
-It can be enabled by specifying your analytics id under plainwhite in `_config.yml`
-
-```yaml
-plainwhite:
-  analytics_id: "< YOUR ID >"
-```
-
 **Sitemap**
 
 It can be toggled by the following line to under plainwhite in `_config.yml`

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -122,15 +122,6 @@
       {{ content }}
     </section>
   </main>
-  {%- if site.plainwhite.analytics_id -%}
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.plainwhite.analytics_id }}"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
-    gtag('config', '{{ site.plainwhite.analytics_id }}');
-  </script>
-  {%- endif -%}
 
   {% if site.plainwhite.search %}
   <script src="/assets/js/simple-jekyll-search.min.js"></script>


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/