### PR TITLE
Add compatibility with baseurl tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ plainwhite:
 
 Search is powered by [Simple-Jekyll-Search](https://github.com/christian-fei/Simple-Jekyll-Search) Jekyll plugin. A `search.json` containing post meta and contents will be generated in site root folder. Plugin JavaScript will then match for posts based on user input. More info and `search.json` customization documentation can be found in plugin repository.
 
+**Base URL**
+
+You can specify a custom base URL (eg. example.com/blog/) by adding the following line to config.yaml. Note that there is no trailing slash on the URL.
+
+```yaml
+baseurl: "/blog"
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/thelehhman/plainwhite-jekyll. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Search is powered by [Simple-Jekyll-Search](https://github.com/christian-fei/Sim
 
 **Base URL**
 
-You can specify a custom base URL (eg. example.com/blog/) by adding the following line to config.yaml. Note that there is no trailing slash on the URL.
+You can specify a custom base URL (eg. example.com/blog/) by adding the following line to `_config.yaml`. Note that there is no trailing slash on the URL.
 
 ```yaml
 baseurl: "/blog"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,9 +8,9 @@
 <body>
   <main class="container">
     <section class="about">
-      <a href="/"><img src="{{ "/assets/portfolio.png" | relative_url }}" alt="{{ site.plainwhite.name }}"></a>
+      <a href="{{ "/" | relative_url}}"><img src="{{ "/assets/portfolio.png" | relative_url }}" alt="{{ site.plainwhite.name }}"></a>
       <h2 id="title">
-        <a href="/">{{ site.plainwhite.name }}</a>
+        <a href="{{ "/" | relative_url }}">{{ site.plainwhite.name }}</a>
       </h2>
       <p class="tagline">{{ site.plainwhite.tagline }}</p>
       <ul class="social">
@@ -115,7 +115,7 @@
           </label>
         </p>
       </div>
-      <script type="text/javascript" src="/assets/js/darkmode.js"></script>
+      <script type="text/javascript" src="{{ "/assets/js/darkmode.js" | relative_url }}"></script>
       {%- endif -%}
     </section>
     <section class="content">
@@ -133,8 +133,49 @@
   {%- endif -%}
 
   {% if site.plainwhite.search %}
-  <script src="/assets/js/simple-jekyll-search.min.js"></script>
-  <script src="/assets/js/search.js"></script>
+  <script src="{{ "/assets/js/simple-jekyll-search.min.js" | relative_url }}"></script>
+  <!-- <script src="{{ "/assets/js/search.js" | relative_url }}"></script> -->
+  <script>
+	window.onload = function () {
+		var sjs = SimpleJekyllSearch({
+			searchInput: document.getElementById('searchbar'),
+			resultsContainer: document.getElementById('search-results'),
+			json: '{{ "search.json" | relative_url }}',
+			searchResultTemplate: '<a href="{url}" target="_blank">{title}</a>',
+			noResultsText: ''
+		});
+
+		/* hack ios safari unfocus */
+		if (/Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent))
+			document.body.firstElementChild.tabIndex = 1;
+
+		var $labelGroup = document.querySelector(".posts-labelgroup");
+		var $searchbar = document.getElementById("searchbar");
+		var $postLabel = document.getElementById("posts-label");
+		var $searchResults = document.querySelector(".search-results");
+		var labelWidth = $postLabel.scrollWidth;
+		$postLabel.style.width = labelWidth + "px";
+
+		$labelGroup.addEventListener("click", function (e) {
+			$searchResults.style.display = null;
+			$postLabel.style.width = "0";
+			$labelGroup.setAttribute("class", "posts-labelgroup focus-within");
+			$searchbar.focus();
+			e.stopPropagation();
+		}, false);
+
+		$labelGroup.addEventListener("mouseleave", function () {
+			document.body.onclick = searchCollapse;
+		});
+
+		var searchCollapse = function (e) {
+			$searchResults.style.display = "none";
+			$labelGroup.setAttribute("class", "posts-labelgroup");
+			$postLabel.style.width = labelWidth + "px";
+			document.body.onclick = null;
+		};
+	}
+  </script>
   {% endif %}
 </body>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -134,48 +134,7 @@
 
   {% if site.plainwhite.search %}
   <script src="{{ "/assets/js/simple-jekyll-search.min.js" | relative_url }}"></script>
-  <!-- <script src="{{ "/assets/js/search.js" | relative_url }}"></script> -->
-  <script>
-	window.onload = function () {
-		var sjs = SimpleJekyllSearch({
-			searchInput: document.getElementById('searchbar'),
-			resultsContainer: document.getElementById('search-results'),
-			json: '{{ "search.json" | relative_url }}',
-			searchResultTemplate: '<a href="{url}" target="_blank">{title}</a>',
-			noResultsText: ''
-		});
-
-		/* hack ios safari unfocus */
-		if (/Safari/.test(navigator.userAgent) && !/Chrome/.test(navigator.userAgent))
-			document.body.firstElementChild.tabIndex = 1;
-
-		var $labelGroup = document.querySelector(".posts-labelgroup");
-		var $searchbar = document.getElementById("searchbar");
-		var $postLabel = document.getElementById("posts-label");
-		var $searchResults = document.querySelector(".search-results");
-		var labelWidth = $postLabel.scrollWidth;
-		$postLabel.style.width = labelWidth + "px";
-
-		$labelGroup.addEventListener("click", function (e) {
-			$searchResults.style.display = null;
-			$postLabel.style.width = "0";
-			$labelGroup.setAttribute("class", "posts-labelgroup focus-within");
-			$searchbar.focus();
-			e.stopPropagation();
-		}, false);
-
-		$labelGroup.addEventListener("mouseleave", function () {
-			document.body.onclick = searchCollapse;
-		});
-
-		var searchCollapse = function (e) {
-			$searchResults.style.display = "none";
-			$labelGroup.setAttribute("class", "posts-labelgroup");
-			$postLabel.style.width = labelWidth + "px";
-			document.body.onclick = null;
-		};
-	}
-  </script>
+  <script src="{{ "/assets/js/search.js" | relative_url }}"></script>
   {% endif %}
 </body>
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,8 +1,11 @@
+---
+---
+
 window.onload = function () {
     var sjs = SimpleJekyllSearch({
         searchInput: document.getElementById('searchbar'),
         resultsContainer: document.getElementById('search-results'),
-        json: '/search.json',
+        json: '{{ "/search.json" | relative_url }}',
         searchResultTemplate: '<a href="{url}" target="_blank">{title}</a>',
         noResultsText: ''
     });


### PR DESCRIPTION
Hi @samarsault 
I have made the following changes to this theme to make it compatible with the tag `baseurl`:

- Added  a section to the README describing how to use the `baseurl` tag (minor change)
- Marked links in `_layouts/default.html` as relative URLs (meaning that they will have the value of `baseurl` prepended to them) (minor change)
- Changed from including `assets/js/search.js` as an external script to embedding it in `_layouts/default.html` to allow for the value of `baseurl` to be prepended to the path to `search.json` (major change)

Cheers,
Alex.