### PR TITLE
Make html lang attribute configurable (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ You can specify a custom base URL (eg. example.com/blog/) by adding the followin
 baseurl: "/blog"
 ```
 
+**Language**
+
+You can set the `lang` attribute of the `<html>` tag on your pages by changing the following line in `_config.yml`:
+
+```yaml
+plainwhite:
+  html_lang: "en"
+```
+
+[See here for a full list of available language codes](https://www.w3schools.com/tags/ref_country_codes.asp)
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/thelehhman/plainwhite-jekyll. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ plainwhite:
   sitemap: true # set to true to generate sitemap.xml content
   search: true # set to true to enable searchbar
   dark_mode: true # set to true to add dark mode toggle
+  html_lang: "en" # set the lang attribute of the <html> tag for the pages. See here for a list of codes: https://www.w3schools.com/tags/ref_country_codes.asp
 
   # generate social links in footer
   social_links:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ site.plainwhite.html_lang }}">
 
 <head>
   {%- include head.html -%}


### PR DESCRIPTION
Hi @samarsault 
This PR adds an option to `_config.yml` to configure the `<html lang="">` attribute as requested in #40 
Cheers,
Alex.