### PR TITLE
Move most of "about" pane to bottom when on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ plainwhite:
       url: "/resume"
 ```
 
+**Mobile**
+
+By default, Plainwhite places the sidebar (logo, name, tagline etc.) above the content on mobile (narrow screens).
+To condense it (moving some things to the bottom of the page and making the rest smaller) so it takes up less space, add the following to your `_config.yml`:
+
+```yaml
+plainwhite:
+  condensed_mobile:
+    - home
+    - post
+    - page
+```
+
+This chooses which layouts (types of page) should be condensed on mobile screens. E.g. if you want everything but the landing page to be condensed, remove `home` from the list. This option does not affect rendering on wider screens.
+
 **Dark mode**
 
 Dark mode can be enabled by setting the `dark_mode` flag in your `_config.yml`

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,10 @@ plainwhite:
   dark_mode: true # set to true to add dark mode toggle
   portfolio_image: "assets/portfolio.png" # the path from the base directory of the site to the image to display (no / at the start)
   html_lang: "en" # set the lang attribute of the <html> tag for the pages. See here for a list of codes: https://www.w3schools.com/tags/ref_country_codes.asp
-
+  condensed_mobile:
+    #- home
+    - page
+    - post
   # generate social links in footer
   social_links:
     twitter: samarsault

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,11 @@
   {%- include head.html -%}
 </head>
 
+{%- if site.plainwhite.condensed_mobile contains page.layout -%}
 {% assign condensed_class = "condensed" %}
+{% else %}
+{% assign condensed_class = "" %}
+{%- endif -%}
 
 <body>
   <main class="container">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,6 +10,8 @@
 <body>
   <main class="container">
     <section class="about">
+      <div class="about-header {{condensed_class}}">
+      <div class="about-title">
       <a href="{{ "/" | relative_url}}">
         {% if site.plainwhite.portfolio_image_dark and site.plainwhite.dark_mode %}
         <img class="light" src="{{site.baseurl }}/{{ site.plainwhite.portfolio_image }}" alt="{{ site.plainwhite.name }}" />
@@ -21,9 +23,11 @@
       <h2 id="title">
         <a href="{{ "/" | relative_url }}">{{ site.plainwhite.name }}</a>
       </h2>
+      </div>
       {%- if site.plainwhite.tagline -%}
       <p class="tagline">{{ site.plainwhite.tagline }}</p>
       {%- endif -%}
+      </div>
       {% capture footer %}
       {%- if site.plainwhite.social_links != '' -%}
       <ul class="social about-footer {{condensed_class}}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,8 @@
   {%- include head.html -%}
 </head>
 
+{% assign condensed_class = "condensed" %}
+
 <body>
   <main class="container">
     <section class="about">
@@ -19,8 +21,12 @@
       <h2 id="title">
         <a href="{{ "/" | relative_url }}">{{ site.plainwhite.name }}</a>
       </h2>
+      {%- if site.plainwhite.tagline -%}
       <p class="tagline">{{ site.plainwhite.tagline }}</p>
-      <ul class="social">
+      {%- endif -%}
+      {% capture footer %}
+      {%- if site.plainwhite.social_links != '' -%}
+      <ul class="social about-footer {{condensed_class}}">
         {%- if site.plainwhite.social_links.github -%}
         <a href="https://github.com/{{ site.plainwhite.social_links.github }}" target="_blank">
           <li>
@@ -28,7 +34,7 @@
           </li>
         </a>
         {%- endif -%}
-		{%- if site.plainwhite.social_links.gitlab -%}
+        {%- if site.plainwhite.social_links.gitlab -%}
         <a href="https://gitlab.com/{{ site.plainwhite.social_links.gitlab }}" target="_blank">
           <li>
             <i class="icon-gitlab"></i>
@@ -106,8 +112,9 @@
         </a>
         {%- endif -%}
       </ul>
+      {%- endif -%}
       {%- if site.plainwhite.navigation -%}
-      <nav class="navigation">
+      <nav class="navigation about-footer {{condensed_class}}">
         <ul>
           {% for link in site.plainwhite.navigation %}
           <li>
@@ -117,25 +124,33 @@
         </ul>
       </nav>
       {%- endif -%}
-      <p>&copy;
+      <p class="about-footer {{condensed_class}}">&copy;
         {{ "now" | date: "%Y" }}</p>
       {%- if site.plainwhite.dark_mode -%}
-      <div>
+      <div class="about-footer {{condensed_class}}">
         <p>Dark Mode
           <i class="icon-moon"></i>
           <label class="switch">
-            <input type="checkbox" id="dark-mode-toggle">
+            <input type="checkbox" class="dark-mode-toggle">
             <span class="slider round" onclick="toggleDarkMode()"></span>
           </label>
         </p>
       </div>
-      <script type="text/javascript" src="{{ "/assets/js/darkmode.js" | relative_url }}"></script>
       {%- endif -%}
+      {% endcapture %}
+      {{ footer }}
     </section>
     <section class="content">
       {{ content }}
     </section>
+    <footer class="{{condensed_class}}">
+      {{ footer }}
+    </footer>
   </main>
+  {% if site.plainwhite.dark_mode %}
+  <script type="text/javascript" src="{{ "/assets/js/darkmode.js" | relative_url }}"></script>
+  {% endif %}
+
   {%- if site.plainwhite.analytics_id -%}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.plainwhite.analytics_id }}"></script>
   <script>

--- a/_sass/plain.scss
+++ b/_sass/plain.scss
@@ -40,6 +40,9 @@ a {
 
 h2 {
   margin: 0.7em 0;
+  @media screen and (max-width: $mobileW) {
+    margin: 0.3em 0;
+  }
 }
 main {
   margin: 0 90px;
@@ -78,7 +81,10 @@ main {
     padding-bottom: 15vh;
     @media screen and (max-width: $mobileW) {
       height: auto;
-      padding: 10vh 0;
+      padding: 5vh 30px;
+    }
+    @media screen and (max-width: $smallMobileW) {
+      padding: 5vh 20px;
     }
     @media screen and (min-width: $mobileW + 1) {
       position: fixed;
@@ -98,7 +104,7 @@ main {
     .tagline {
       text-align: center;
       font-size: 22px;
-      margin-top: 17px;
+      margin-top: 0px;
       color: #aaa;
       white-space: pre-wrap;
       line-height: normal;
@@ -108,6 +114,16 @@ main {
     }
     img.dark {
       display: none;
+    }
+    .about-header {
+      display: flex;
+      flex-direction: column;
+      .about-title {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-bottom: 17px;
+      }
     }
   }
 }
@@ -213,7 +229,7 @@ main {
 .posts,
 .post-container {
   list-style-type: none;
-  margin: 45px 30px;
+  margin: 0px 30px;
   @media screen and (max-width: $smallMobileW) {
     margin-left: 20px;
     margin-right: 20px;
@@ -285,6 +301,24 @@ footer {
 }
 @media screen and (max-width: $mobileW) {
   .about {
+    .about-header.condensed {
+      align-items: start;
+      align-self: start;
+      .about-title {
+        flex-direction: row;
+        margin-bottom: 10px;
+        img {
+          max-height: 40px;
+        }
+        h2 {
+          margin: 0 10px;
+        }
+      }
+      .tagline {
+        font-size: 18px;
+        margin-bottom: 0px;
+      }
+    }
     .about-footer.condensed {
       display: none;
     }

--- a/_sass/plain.scss
+++ b/_sass/plain.scss
@@ -119,7 +119,6 @@ main {
 .social {
   list-style-type: none;
   padding: 0;
-  margin-top: 0;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -278,5 +277,26 @@ table {
   th {
     background-color: #eee;
     font-family: Raleway;
+  }
+}
+
+footer {
+  display: none;
+}
+@media screen and (max-width: $mobileW) {
+  .about {
+    .about-footer.condensed {
+      display: none;
+    }
+  }
+  footer.condensed {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0 40px;
+    @media screen and (max-width: $smallMobileW){
+      margin: 0 20px;
+    }
+    border-top: 1px solid #eee;
   }
 }

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -27,7 +27,6 @@ function deleteCookie(name) { setCookie(name, '', -1); }
 const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 var theme = getCookie('theme');
 if ( (theme === null && userPrefersDark) || theme === 'dark') {
-    var toggleInput = document.querySelector('#dark-mode-toggle');
-    toggleInput.checked = true;
     toggleDarkMode();
+    document.querySelectorAll('.dark-mode-toggle').forEach(ti => ti.checked = true);
 }


### PR DESCRIPTION
Also, condense logo, name, and tagline when on mobile.

Fixes issue #78.
I'm new to Jekyll templates, so don't know if everything here makes sense, or is aesthetically right.

Screenshot of mobile:

![image](https://user-images.githubusercontent.com/65734019/92968705-e64a3880-f47b-11ea-92a5-2a8430e8157a.png)

Screenhot of desktop:

![image](https://user-images.githubusercontent.com/65734019/92968745-f82bdb80-f47b-11ea-96d3-0c9b4607cb49.png)
