### PR TITLE
Set the SameSite attribute on the theme cookie

### DIFF
--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -18,7 +18,7 @@ function getCookie(name) {
 function setCookie(name, value, days) {
     var d = new Date;
     d.setTime(d.getTime() + 24*60*60*1000*days);
-    document.cookie = name + "=" + value + ";path=/;expires=" + d.toGMTString();
+    document.cookie = name + "=" + value + ";path=/;SameSite=strict;expires=" + d.toGMTString();
 }
 
 function deleteCookie(name) { setCookie(name, '', -1); }


### PR DESCRIPTION
To avoid Firefox warning:

"Cookie “theme” will be soon rejected because it has the
“SameSite” attribute set to “None” or an invalid value,
without the “secure” attribute."