### PR TITLE
Make sure the site doesn't flicker white before turning black

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,3 +5,6 @@
 <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
 <title>{{ page.title | default: site.title }}</title>
 {% seo %}
+{% if site.plainwhite.dark_mode %}
+<script type="text/javascript" src="{{ "/assets/js/darkmode.js" | relative_url }}"></script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -129,7 +129,6 @@
           </label>
         </p>
       </div>
-      <script type="text/javascript" src="{{ "/assets/js/darkmode.js" | relative_url }}"></script>
       {%- endif -%}
     </section>
     <section class="content">

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -27,7 +27,21 @@ function deleteCookie(name) { setCookie(name, '', -1); }
 const userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 var theme = getCookie('theme');
 if ( (theme === null && userPrefersDark) || theme === 'dark') {
-    var toggleInput = document.querySelector('#dark-mode-toggle');
-    toggleInput.checked = true;
-    toggleDarkMode();
+    var checkDarkDone = false;
+    function checkDark() {
+        if (!checkDarkDone) {
+            toggleDarkMode();
+        }
+        checkDarkDone = true;
+    };
+
+    function toggleSwitch() {
+        document.querySelectorAll('#dark-mode-toggle').forEach(ti => ti.checked = true);
+    };
+
+    // Attempt both requestAnimationFrame and DOMContentLoaded, whichever comes first.
+    if (window.requestAnimationFrame) window.requestAnimationFrame(checkDark);
+    window.addEventListener('DOMContentLoaded', checkDark);
+
+    window.addEventListener('DOMContentLoaded', toggleSwitch);
 }


### PR DESCRIPTION
when darkmode is active.

This puts the darkmode script into the head, and delays the darkmode
toggle code until the DOM is available.

I found there was still a flicker if the script was at the start of
the body.