### PR TITLE
fix mail icon, remove rss (was never implemented?)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,6 @@ plainwhite:
     twitter: samarsault
     github:  samarsault
     linkedIn: in/samarsault
-    #rss: rss
     #dribbble: jekyll
     #flickr:   jekyll
     #instagram: jekyll

--- a/_sass/ext/_fonts.scss
+++ b/_sass/ext/_fonts.scss
@@ -1,11 +1,11 @@
 @font-face {
   font-family: 'fontello';
-  src: url('../font/fontello.eot?5c4bea36');
-  src: url('../font/fontello.eot?5c4bea36#iefix') format('embedded-opentype'),
-       url('../font/fontello.woff2?5c4bea36') format('woff2'),
-       url('../font/fontello.woff?5c4bea36') format('woff'),
-       url('../font/fontello.ttf?5c4bea36') format('truetype'),
-       url('../font/fontello.svg?5c4bea36#fontello') format('svg');
+  src: url('../font/fontello.eot?37382099');
+  src: url('../font/fontello.eot?37382099#iefix') format('embedded-opentype'),
+       url('../font/fontello.woff2?37382099') format('woff2'),
+       url('../font/fontello.woff?37382099') format('woff'),
+       url('../font/fontello.ttf?37382099') format('truetype'),
+       url('../font/fontello.svg?37382099#fontello') format('svg');
   font-weight: normal;
   font-style: normal;
 }
@@ -15,7 +15,7 @@
 @media screen and (-webkit-min-device-pixel-ratio:0) {
   @font-face {
     font-family: 'fontello';
-    src: url('../font/fontello.svg?5c4bea36#fontello') format('svg');
+    src: url('../font/fontello.svg?37382099#fontello') format('svg');
   }
 }
 */


### PR DESCRIPTION
The mail icon did not work, I tried to undo the changes in _fonts.scss which resulted in it working. Tested all icons in firefox and chromium, all working properly. Removed the option for an RSS icon as it was never fully implemented. 